### PR TITLE
Files for release one

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Currently, there are a bunch of issue and pull request templates (details below)
 - [ ] [`test-suite`](./ISSUE_TEMPLATE/test-suite.yaml) : Missing or incomplete tests in our codebase.
 
 ### Pull Request Templates
+> There will likely be only a single PR template for now. Was not able to get multiple templates working.
+>> An alternative can be multiple templates here and when connecting to main repos, we select one, most appropriate for the repo.
+
 
 - [ ] convenience :
 - [ ] feature :


### PR DESCRIPTION
> Linked sc issue : [sc-319](https://app.shortcut.com/stubs/story/319/release-v1-templates)

There a multiple PRs into this one that each address a specific template. This then merges into #2, which merges into `master`. This extra step is only because I wanted to link the branch and PR to shortcut, but renaming the existing branch would have closed that PR, which I do not want.

Also, note that adding a reviewer to this pr, will move the sc ticket to _In Review_, so do that only after the rest are done.