### PR TITLE
Bug Report Issue Form

### DIFF
--- a/ISSUE_TEMPLATE/bug-report.yaml
+++ b/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,6 +1,3 @@
-## Created: 2023-06-13 @thisispalash
-## Updated: 2023-06-15 @thisispalash
-
 name: 'Bug Report'
 description: 'File a bug report'
 title: '[Bug]: '

--- a/ISSUE_TEMPLATE/bug-report.yaml
+++ b/ISSUE_TEMPLATE/bug-report.yaml
@@ -31,21 +31,6 @@ body: # * = required
     validations:
       required: true
   
-  # [textarea] steps to reproduce *
-  - type: textarea
-    id: steps
-    attributes:
-      label: 'Steps to reproduce'
-      description: 'Please list the steps to reproduce the bug. Better yet, make a video (on loom)!'
-      placeholder: |
-        1. Go to ...
-        2. Click on ...
-        3. ...
-        
-        [See video](https://www.loom.com/...)
-    validations:
-      required: true
-  
   # [textarea] what was expected *
   - type: textarea
     id: expectations
@@ -89,6 +74,21 @@ body: # * = required
   
   ## Debugging info ##
 
+  # [textarea] steps to reproduce *
+  - type: textarea
+    id: steps
+    attributes:
+      label: 'Steps to reproduce'
+      description: 'Please list the steps to reproduce the bug. Better yet, make a video (on loom)!'
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. ...
+        
+        [See video](https://www.loom.com/...)
+    validations:
+      required: true
+  
   # [dropdown] browser *
   - type: dropdown
     id: browsers

--- a/ISSUE_TEMPLATE/bug-report.yaml
+++ b/ISSUE_TEMPLATE/bug-report.yaml
@@ -2,7 +2,7 @@ name: 'Bug Report'
 description: 'File a bug report'
 title: '[Bug]: '
 labels: ['bug', 'help wanted']
-assignees: ['']
+assignees: ['henry1jin']
 body: # * = required
 
   # [markdown] information
@@ -12,11 +12,11 @@ body: # * = required
         Thanks for taking the time to fill out this bug report! You will need ~5 minutes to fill this out. 
         
         Steps overview,
-          - [ ] describe bug
-          - [ ] record bug
-          - [ ] explain why bug
-          - [ ] consider fixes
-          - [ ] add debugging info
+          1. describe bug
+          2. record bug
+          3. explain why bug
+          4. consider fixes
+          5. add debugging info
 
   # [textarea] what happened *
   - type: textarea
@@ -24,8 +24,7 @@ body: # * = required
     attributes:
       label: 'What happened?'
       description: 'Describe, briefly, what happened; ie, what the bug is. Please also attach screenshots if possible.'
-      placeholder: 'Please describe what happened.'
-      value: |
+      placeholder: |
         ### Bug Description
 
         ### Screenshots
@@ -38,8 +37,7 @@ body: # * = required
     attributes:
       label: 'Steps to reproduce'
       description: 'Please list the steps to reproduce the bug. Better yet, make a video (on loom)!'
-      placeholder: 'Please list steps or link video.'
-      value: |
+      placeholder: |
         1. Go to ...
         2. Click on ...
         3. ...
@@ -54,8 +52,7 @@ body: # * = required
     attributes:
       label: 'What did you expect or want to have happened?'
       description: 'Please describe what you expected to have happened. If you have any links to previous discussions or designs, please link them here.'
-      placeholder: 'Please describe your expectations.'
-      value: |
+      placeholder: |
         The bug shouldn't have happened because...
     validations:
       required: true
@@ -66,13 +63,12 @@ body: # * = required
     attributes:
       label: 'What do you think is causing this bug? How would you fix it?'
       description: 'Please describe what you think is causing this bug. If you have any ideas on how to fix it, please describe them here. If you have any links to previous discussions or designs, please link them here.'
-      placeholder: 'Please discuss the bug a little.'
-      value: |
+      placeholder: |
         ### Cause
         The bug is probably being caused by... 
         
         ### Fix
-        perhaps fix by...'
+        perhaps this can be fixed if we do...
     validations:
       required: true
  
@@ -81,7 +77,7 @@ body: # * = required
     id: severity
     attributes:
       label: 'Severity'
-      description: 'How critical would you think this bug is?'
+      description: 'How critical would you think this bug is? (1 : highest priority)'
       options:
         - 1 (Breaking)
         - 2 (Not breaking, but important)
@@ -104,6 +100,7 @@ body: # * = required
         - Chrome
         - Safari
         - Microsoft Edge
+        - Other
     validations:
       required: true
   

--- a/ISSUE_TEMPLATE/bug-report.yaml
+++ b/ISSUE_TEMPLATE/bug-report.yaml
@@ -13,10 +13,9 @@ body: # * = required
         
         Steps overview,
           1. describe bug
-          2. record bug
-          3. explain why bug
-          4. consider fixes
-          5. add debugging info
+          2. explain why bug
+          3. consider fixes
+          4. add debugging info
 
   # [textarea] what happened *
   - type: textarea
@@ -73,6 +72,12 @@ body: # * = required
       required: true
   
   ## Debugging info ##
+
+  # [markdown] information
+  - type: markdown
+    attributes:
+      value: |
+        This section asks you for specific debugging information so we can reproduce the bug, _and squash it_!
 
   # [textarea] steps to reproduce *
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Currently, there are a bunch of issue and pull request templates (details below)
 
 ### Issue Templates
 
-- [x] [`annoying-ui`](./ISSUE_TEMPLATE/annoying-ui.yaml) : Something that is off in the UI of the application.
-- [x] [`bug-report`](./ISSUE_TEMPLATE/bug-report.yaml) : Quite self-explanatory. These issues may lead to larger issues.
-- [x] [`codebase-improvement`](./ISSUE_TEMPLATE/codebase-improvement.yaml) : These are for optimizations and for improving dev experience as we build.
-- [x] [`documentation`](./ISSUE_TEMPLATE/documentation.yaml) : Docs are either missing or incorrect, for the public or for the codebase.
-- [x] [`feature-request`](./ISSUE_TEMPLATE/feature-request.yaml) : A new feature for the product. These should ideally be also coming in from the public.
-- [x] [`moonshot`](./ISSUE_TEMPLATE/moonshot.yaml) : A crazy idea that has exponential scale, but would require some shift in current focus.
-- [x] [`observer-ux`](./ISSUE_TEMPLATE/observer-ux.yaml) : Similar to `annoying-ui`, but for user experience.
+- [ ] [`annoying-ui`](./ISSUE_TEMPLATE/annoying-ui.yaml) : Something that is off in the UI of the application.
+- [x] [`bug-report`](./ISSUE_TEMPLATE/bug-report.yaml) : Quite self-explanatory. Note the order of questions to produce richer reports.
+- [ ] [`codebase-improvement`](./ISSUE_TEMPLATE/codebase-improvement.yaml) : These are for optimizations and for improving dev experience as we build.
+- [ ] [`documentation`](./ISSUE_TEMPLATE/documentation.yaml) : Docs are either missing or incorrect, for the public or for the codebase.
+- [ ] [`feature-request`](./ISSUE_TEMPLATE/feature-request.yaml) : A new feature for the product. These should ideally be also coming in from the public.
+- [ ] [`moonshot`](./ISSUE_TEMPLATE/moonshot.yaml) : A crazy idea that has exponential scale, but would require some shift in current focus.
+- [ ] [`observer-ux`](./ISSUE_TEMPLATE/observer-ux.yaml) : Similar to `annoying-ui`, but for user experience.
 - [ ] [`test-suite`](./ISSUE_TEMPLATE/test-suite.yaml) : Missing or incomplete tests in our codebase.
 
 ### Pull Request Templates


### PR DESCRIPTION
## Core Objectives
> Why this issue-form template even exists

1. Create bug reports that @griffinthegrand or @trxnt find.
2. As a potential intake of bug reports from users.
3. Structured data for [`stubs-butler`](https://github.com/shil-me/stubs-bot) and _`stubs-agent`_.

## Questioning Strategy
> How are the questions laid out? For eg, are they _what > why > how_ or _what > how > why_, or something else?
>> The idea here is to allow the template form to aid in the thinking of the issue opener

1. The report is _what happened_ > _what was expected_ > _solutions_; this is for reporter.
2. Then comes the debugging info section for us devs. This will likely need some work. (cc @henry1jin @iamzubin)

## Team Readability
> What does the issue look like once submitted? Will that be readable enough for the team to get started thinking about the issue?

1. For an example, see @griffinthegrand's issue — https://github.com/shil-me/stubs-app/issues/431
2. I would say the description is rather long, especially if images are included. However, not sure how to reduce length without losing resolution.

## Shortcut Connectivity
> How is this issue connected with shortcut? Make sure to list all side-effects!

1. The severity is a 1-to-1 mapping with priority in shortcut. 1 is highest, 5 is lowest.
2. Some integration with epics is needed, but we would need our butler to do that.

## Notes to keep in mind
> What are some shortcomings or nuances that one must be aware of when they are opening, or reading, this issue?

1. The debugging info section can be a little better.

## Further Work
> Is there something thats left to be addressed once this PR is merged? Are there any blockers?

1. Integrate bugs and ticketing system tightly using [`stubs-butler`](https://github.com/shil-me/stubs-bot)