### PR TITLE
Annoying UI Issue Form

### DIFF
--- a/ISSUE_TEMPLATE/annoying-ui.yaml
+++ b/ISSUE_TEMPLATE/annoying-ui.yaml
@@ -1,10 +1,7 @@
-## Created: 2023-06-13 @thisispalash
-## Updated: 2023-06-15 @thisispalash
-
 name: 'Better UI'
 description: 'Use this template to report any breaking UI or annouying UI issues.'
-title: '[Better UI]: '
-labels: ['ui-fix', 'enhancement']
+title: '[UI]: '
+labels: ['ui-fix', '']
 assignees: ['']
 body: # * = required
 

--- a/ISSUE_TEMPLATE/annoying-ui.yaml
+++ b/ISSUE_TEMPLATE/annoying-ui.yaml
@@ -2,7 +2,7 @@ name: 'Better UI'
 description: 'Use this template to report any breaking UI or annouying UI issues.'
 title: '[UI]: '
 labels: ['ui-fix', '']
-assignees: ['']
+assignees: ['ChinmayGopal931']
 body: # * = required
 
   # [markdown] information
@@ -17,19 +17,7 @@ body: # * = required
     attributes:
       label: 'Description'
       description: 'Describe the issue. _What_ is the annoying / breaking thing in the UI?'
-      placeholder: 'pls sir, reveal your secrets!'
-      value: 'When this thing happens, this breaks, which is extremely annoying because ...'
-    validations:
-      required: true
-  
-  # [textarea] the-how *
-  - type: textarea
-    id: the-how
-    attributes:
-      label: 'Issue Journey'
-      description: 'How did you come across this issue? Was it something related to what you were working on? Is there any additional context necessary to understand this issue? Feel free to include any media, such as screens or looms.'
-      placeholder: pls sir, let us travel together!
-      value: 'When you click this thing, the thing happens. To get to this stage, I was doing ...'
+      placeholder: 'pls, reveal your secrets!'
     validations:
       required: true
   
@@ -37,10 +25,19 @@ body: # * = required
   - type: textarea
     id: the-why
     attributes:
+      label: 'Issue Journey'
+      description: 'How did you come across this issue? _Why_ is it annoying / breaking?'
+      placeholder: 'let us see what you see!'
+    validations:
+      required: true
+  
+  # [textarea] the-how *
+  - type: textarea
+    id: the-how
+    attributes:
       label: 'Considerations'
-      description: 'Any thoughts on how to fix this? Are there multiple options? Can a fix break something else? Feel free to attach any prior discussions or media.'
-      placeholder: pls sir, help us!
-      value: 'Maybe it is breaking because of ..., so we can maybe fix by ...'
+      description: 'Any thoughts on how to address this? _How_ can this not be annoying / breaking?'
+      placeholder: 'pls , help us!'
     validations:
       required: true
   
@@ -49,7 +46,7 @@ body: # * = required
     id: severity
     attributes:
       label: 'Severity'
-      description: 'How critical would you think this issue is?'
+      description: 'How critical would you think this issue is? (1 : highest priority)'
       options:
         - 1 (Breaking)
         - 2 (Not breaking, but important)


### PR DESCRIPTION
## Core Objectives
> Why this issue-form template even exists

1. This template is to report on specifically UI things, such as border overflowing, or toast too long, etc. Anything that makes the product _ugly_ to our users.
2. Another objective is to track _delightful features_ (such as settings-gear-icon turning when hovered) to enhance the _beauty_ of the product.

## Questioning Strategy
> How are the questions laid out? For eg, are they _what > why > how_ or _what > how > why_, or something else?
>> The idea here is to allow the template form to aid in the thinking of the issue opener

1. The base strat is _what > why > how_; ie, _what the ui fix is_, _why you want it_, and _how to implement_.
2. Also asks for severity or priority.
3. See the issue form in action — https://github.com/shil-me/stubs-bot/issues/new/choose (select _Better UI_).

## Team Readability
> What does the issue look like once submitted? Will that be readable enough for the team to get started thinking about the issue?

1. The key section for post submission collaborating is the _how_ section (or _Considerations_). This lets us think about the issue anywhere and develop quickly if need be.

## Shortcut Connectivity
> How is this issue connected with shortcut? Make sure to list all side-effects!

1. These would be categorized at _bugs_ by default on shortcut by [`stubs-butler`](https://github.com/shil-me/stubs-bot).
4. The severity is a 1-to-1 mapping with priority (1 is highest, 5 is lowest).

## Notes to keep in mind
> What are some shortcomings or nuances that one must be aware of when they are opening, or reading, this issue?

_N/A_

## Further Work
> Is there something thats left to be addressed once this PR is merged? Are there any blockers?

1. Perhaps find a way for our bot to connect figma in this. Or vercel preview links? cc: @iamzubin 
